### PR TITLE
Add viewport metatag to head

### DIFF
--- a/views/includes/head.jade
+++ b/views/includes/head.jade
@@ -2,3 +2,4 @@ head
   title Entre na comunidade #{community} no Slack!
   link(rel='stylesheet', href='//fonts.googleapis.com/css?family=Open+Sans:400,700')
   link(rel='stylesheet', href='css/main.css')
+  meta(name='viewport', content='width=device-width, initial-scale=1')


### PR DESCRIPTION
Notei que o convite não estava sendo bem exibido em dispositivos móveis, então adicionei a tag viewport e acho que já soluciona nossos problemas :-)

![slack wordpress invite on mobile](https://cloud.githubusercontent.com/assets/1847217/25436847/f0d88858-2a6a-11e7-9800-c16ec12d6f1d.gif)
